### PR TITLE
Receive all exception info in context exit handler

### DIFF
--- a/pubsub_util.py
+++ b/pubsub_util.py
@@ -41,7 +41,7 @@ class Publisher:
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, exc_traceback):
         self.flush()
 
     def send_bytes(self, message: bytes):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pubsub_util",
-    version="1.0.0",
+    version="1.0.1",
     author="Ivana Mance",
     author_email="ivana.mance@photomath.com",
     description="Util for subscribing or publishing messages to Googles PubSub topics",


### PR DESCRIPTION
Added exception info params in __exit__ so that if an exception is raised in the Publisher context, __exit__ won't crash.